### PR TITLE
Add roslaunch python lib

### DIFF
--- a/repositories/ros_comm.BUILD.bazel
+++ b/repositories/ros_comm.BUILD.bazel
@@ -181,6 +181,19 @@ py_binary(
 )
 
 py_library(
+    name = "roslaunch_lib",
+    srcs = glob(
+        ["tools/roslaunch/src/**/*.py"],
+    ),
+    imports = ["tools/roslaunch/src"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":rosgraph_lib",
+        requirement("defusedxml"),
+    ],
+)
+
+py_library(
     name = "rosmaster_lib",
     srcs = glob(
         ["tools/rosmaster/src/**/*.py"],


### PR DESCRIPTION
Similar to https://github.com/mvukov/rules_ros/pull/5, this adds the missing `roslanch` python library