### PR TITLE
Update rules_python

### DIFF
--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -10,9 +10,9 @@ def ros_repositories():
     maybe(
         http_archive,
         name = "rules_python",
-        sha256 = "c68bdc4fbec25de5b5493b8819cfc877c4ea299c0dcb15c244c5a00208cde311",
-        strip_prefix = "rules_python-0.31.0",
-        url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.31.0.tar.gz",
+        sha256 = "4912ced70dc1a2a8e4b86cec233b192ca053e82bc72d877b98e126156e8f228d",
+        strip_prefix = "rules_python-0.32.2",
+        url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.32.2.tar.gz",
     )
 
     maybe(


### PR DESCRIPTION
I try to solve the breaking changes in `rules_py` introduced in https://github.com/aspect-build/rules_py/pull/311. For this, I first bump `rules_python`, althoug it should be already in this version according to https://github.com/bazelbuild/rules_python/blob/main/CHANGELOG.md#changed-2.