### PR TITLE
Add example for bzlmod and fix usage

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -41,9 +41,9 @@ use_repo(
 bazel_dep(name = "rules_boost")
 archive_override(
     module_name = "rules_boost",
-    integrity = "sha256-I1iTdF3qckTmDRab+0yjA37Iya9AOGvEGJVoPtfpADM=",
-    strip_prefix = "rules_boost-42d8155d8f20a1aee8ee20b7903a495bdfb9befd",
-    urls = "https://github.com/nelhage/rules_boost/archive/42d8155d8f20a1aee8ee20b7903a495bdfb9befd.zip",
+    integrity = "sha256-EEmldYvkzka7KLDMgziSgCXDWK9J04/F3DBdFnv+188=",
+    strip_prefix = "rules_boost-8fa193c4e21daaa2d46ff6b9c2b5a2de70b6caa1",
+    urls = "https://github.com/nelhage/rules_boost/archive/8fa193c4e21daaa2d46ff6b9c2b5a2de70b6caa1.zip",
 )
 
 non_module_boost_repositories = use_extension("@rules_boost//:boost/repositories.bzl", "non_module_dependencies")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,7 +13,6 @@ bazel_dep(name = "lz4", version = "1.9.4")
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "rules_foreign_cc", version = "0.11.1")
-
 bazel_dep(name = "rules_python", version = "0.34.0")
 
 non_module_ros_repositories = use_extension("//ros:extensions.bzl", "non_module_dependencies")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,7 +14,7 @@ bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "rules_foreign_cc", version = "0.11.1")
 
-bazel_dep(name = "rules_python", version = "0.33.2", dev_dependency = True)
+bazel_dep(name = "rules_python", version = "0.34.0")
 
 non_module_ros_repositories = use_extension("//ros:extensions.bzl", "non_module_dependencies")
 use_repo(

--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -1,0 +1,13 @@
+bazel_dep(name = "rules_ros")
+local_path_override(
+    module_name = "rules_ros",
+    path = "../..",
+)
+
+bazel_dep(name = "rules_boost")
+archive_override(
+    module_name = "rules_boost",
+    integrity = "sha256-I1iTdF3qckTmDRab+0yjA37Iya9AOGvEGJVoPtfpADM=",
+    strip_prefix = "rules_boost-42d8155d8f20a1aee8ee20b7903a495bdfb9befd",
+    urls = "https://github.com/nelhage/rules_boost/archive/42d8155d8f20a1aee8ee20b7903a495bdfb9befd.zip",
+)

--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -7,7 +7,7 @@ local_path_override(
 bazel_dep(name = "rules_boost")
 archive_override(
     module_name = "rules_boost",
-    integrity = "sha256-I1iTdF3qckTmDRab+0yjA37Iya9AOGvEGJVoPtfpADM=",
-    strip_prefix = "rules_boost-42d8155d8f20a1aee8ee20b7903a495bdfb9befd",
-    urls = "https://github.com/nelhage/rules_boost/archive/42d8155d8f20a1aee8ee20b7903a495bdfb9befd.zip",
+    integrity = "sha256-EEmldYvkzka7KLDMgziSgCXDWK9J04/F3DBdFnv+188=",
+    strip_prefix = "rules_boost-8fa193c4e21daaa2d46ff6b9c2b5a2de70b6caa1",
+    urls = "https://github.com/nelhage/rules_boost/archive/8fa193c4e21daaa2d46ff6b9c2b5a2de70b6caa1.zip",
 )

--- a/examples/chatter/BUILD.bazel
+++ b/examples/chatter/BUILD.bazel
@@ -94,7 +94,7 @@ py_binary(
 # the deployment and start the launcher.
 ros_launch(
     name = "chatter",
-    launch_files = [":chatter.launch"],
+    launch_files = ["chatter.launch"],
     nodes = [
         ":talker",
         ":listener",


### PR DESCRIPTION
Add an example for how to consume via bzlmod and fixes https://github.com/mvukov/rules_ros/issues/32 by removing the `dev_dependency = True` from `rules_python`.

Also bumps `rules_python` to the latest version.