### PR TITLE
Define compatible targets for cpp_common

### DIFF
--- a/ros/repositories/roscpp_core.BUILD.bazel
+++ b/ros/repositories/roscpp_core.BUILD.bazel
@@ -15,6 +15,12 @@ cc_ros_library(
         "HAVE_CXXABI_H",
         "HAVE_GLIBC_BACKTRACE",
     ],
+    target_compatible_with = selects.with_or(
+        {
+            ("@platforms//os:linux", "@platforms//os:macos"): [],
+            "//conditions:default": ["@platforms//:incompatible"],
+        },
+    ),
     visibility = ["//visibility:public"],
     deps = [
         "@boost//:system",


### PR DESCRIPTION
[These defines](https://github.com/mvukov/rules_ros/blob/2a53b870dc2bd304aea6228403f77bcbbc069b8c/ros/repositories/roscpp_core.BUILD.bazel#L13-L17) might be also difficult on other platforms so we don't want to build them.

Follow up of https://github.com/mvukov/rules_ros/pull/34