### PR TITLE
Add Bazel 8 to BCR presubmit

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: "examples"
   matrix:
     platform: ["debian10", "ubuntu2204"]
-    bazel: ["7.x", "6.x"]
+    bazel: ["8.x", "7.x", "6.x"]
   tasks:
     run_tests:
       name: "Run test module"


### PR DESCRIPTION
New submits on BCR should test for Bazel 8 as proposed in https://github.com/bazelbuild/bazel-central-registry/pull/3471#discussion_r1896017534